### PR TITLE
add scripts to upload test cases

### DIFF
--- a/public/javascripts/script.js
+++ b/public/javascripts/script.js
@@ -209,6 +209,7 @@ app.controller('SearchController', function($scope, $rootScope, $sce, $http) {
         results: searchresults
       };
       
+      $scope.log.foundInPelias = success;
       if (!success) {
         //call nominatum
         $scope.button.class = found.class;

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -24,6 +24,11 @@ function addTests( testsJson, cb ){
       process.exit( 1 );
     }
 
+    if( docs.length === 0 ){
+      console.error( 'No test cases found in the MongoDB Pelias collection.' );
+      process.exit( 2 );
+    }
+
     var existingInputs = testsJson.tests.map( function ( test ){
       return test.in.input;
     });

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -5,7 +5,6 @@
  */
 
 var fs = require( 'fs' );
-var git = require( 'nodegit' );
 var mongo = require( 'mongodb' );
 var monk = require( 'monk' );
 var db = monk( 'localhost:27017/pelias' );

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -1,9 +1,20 @@
+/**
+ * Given a path to a `pelias/acceptance-tests` tests JSON file, add the tests
+ * in the local Mongo server's Pelias collection (as stored by the feedback
+ * app) to it.
+ */
+
 var fs = require( 'fs' );
 var git = require( 'nodegit' );
 var mongo = require( 'mongodb' );
 var monk = require( 'monk' );
 var db = monk( 'localhost:27017/pelias' );
 
+/**
+ * Extract tests-cases from Mongo, conform them to the
+ * `pelias/acceptance-tests` format, inject them into the `testsJson` object,
+ * and pass it to `cb()`.
+ */
 function addTests( testsJson, cb ){
   var peliasCollection = db.get( 'pelias' );
 
@@ -39,6 +50,10 @@ function addTests( testsJson, cb ){
   });
 }
 
+/**
+ * Modify the JSON tests file specified by `testFilePath`, adding test cases to
+ * its `tests` property.
+ */
 function updateTestFile( testFilePath ){
   var testsJson = JSON.parse(fs.readFileSync( testFilePath ));
   addTests( testsJson, function writeNewFile( newTestJson ){

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -1,8 +1,8 @@
 var fs = require( 'fs' );
 var git = require( 'nodegit' );
-var mongo = require('mongodb');
-var monk = require('monk');
-var db = monk('localhost:27017/pelias');
+var mongo = require( 'mongodb' );
+var monk = require( 'monk' );
+var db = monk( 'localhost:27017/pelias' );
 
 function addTests( testsJson, cb ){
   var peliasCollection = db.get( 'pelias' );
@@ -20,10 +20,13 @@ function addTests( testsJson, cb ){
         delete testCaseProps.id;
         expectedOutput = testCaseProps;
       }
+      else if( 'selected' in doc ){
+        expectedOutput = doc.selected[ 0 ].display_name;
+      }
 
       testsJson.tests.push({
         id: 1,
-        user: "feedback-app",
+        user: 'feedback-app',
         in: {
           input: doc.query
         },
@@ -44,7 +47,10 @@ function updateTestFile( testFilePath ){
 }
 
 if( process.argv.length !== 3 ){
-  console.error( 'Incorrect number of arguments.' );
+  console.error(
+    'Incorrect number of arguments. Usage:\n\n' +
+    '\tnode generate_tests.js PATH/TO/acceptance-tests/test_cases/search.json'
+  );
   process.exit( 1 );
 }
 else {

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -24,6 +24,8 @@ function addTests( testsJson, cb ){
       process.exit( 1 );
     }
 
+    var timestamp = new Date().getTime().toString() + ':';
+    var testCaseId = 0;
     docs.forEach( function ( doc ){
       var expectedOutput = null;
       if( doc.foundInPelias ){
@@ -35,14 +37,24 @@ function addTests( testsJson, cb ){
         expectedOutput = doc.selected[ 0 ].display_name;
       }
 
-      testsJson.tests.push({
-        id: 1,
+      var testCase = {
+        id: timestamp + testCaseId++,
         user: 'feedback-app',
         in: {
           input: doc.query
         },
         out: expectedOutput
-      });
+      };
+
+      if( doc.foundInPelias ){
+        for( var ind = 0; ind < doc.results.length; ind++ ){
+          if( doc.results[ ind ].icon === 'check' ){
+            testCase.priorityThresh = ind + 1;
+          }
+        }
+      }
+
+      testsJson.tests.push(testCase);
     });
 
     peliasCollection.remove( {}, function (){

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -31,7 +31,7 @@ function addTests( testsJson, cb ){
         delete testCaseProps.id;
         expectedOutput = testCaseProps;
       }
-      else if( 'selected' in doc ){
+      else if( 'selected' in doc && doc.selected.length > 0 ){
         expectedOutput = doc.selected[ 0 ].display_name;
       }
 
@@ -45,8 +45,10 @@ function addTests( testsJson, cb ){
       });
     });
 
-    cb( testsJson );
-    db.close();
+    peliasCollection.remove( {}, function (){
+      db.close();
+      cb( testsJson );
+    });
   });
 }
 

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -24,9 +24,18 @@ function addTests( testsJson, cb ){
       process.exit( 1 );
     }
 
+    var existingInputs = testsJson.tests.map( function ( test ){
+      return test.in.input;
+    });
+
     var timestamp = new Date().getTime().toString() + ':';
     var testCaseId = 0;
     docs.forEach( function ( doc ){
+      if( existingInputs.indexOf( doc.query ) !== -1 ){
+        return;
+      }
+      existingInputs.push( doc.query );
+
       var expectedOutput = null;
       if( doc.foundInPelias ){
         var testCaseProps = doc.selected[ 0 ].properties;

--- a/upload-test-cases/generate_tests.js
+++ b/upload-test-cases/generate_tests.js
@@ -1,0 +1,52 @@
+var fs = require( 'fs' );
+var git = require( 'nodegit' );
+var mongo = require('mongodb');
+var monk = require('monk');
+var db = monk('localhost:27017/pelias');
+
+function addTests( testsJson, cb ){
+  var peliasCollection = db.get( 'pelias' );
+
+  peliasCollection.find({}, function (err, docs){
+    if( err ){
+      console.error( err );
+      process.exit( 1 );
+    }
+
+    docs.forEach( function ( doc ){
+      var expectedOutput = null;
+      if( doc.foundInPelias ){
+        var testCaseProps = doc.selected[ 0 ].properties;
+        delete testCaseProps.id;
+        expectedOutput = testCaseProps;
+      }
+
+      testsJson.tests.push({
+        id: 1,
+        user: "feedback-app",
+        in: {
+          input: doc.query
+        },
+        out: expectedOutput
+      });
+    });
+
+    cb( testsJson );
+    db.close();
+  });
+}
+
+function updateTestFile( testFilePath ){
+  var testsJson = JSON.parse(fs.readFileSync( testFilePath ));
+  addTests( testsJson, function writeNewFile( newTestJson ){
+    fs.writeFile( testFilePath, JSON.stringify( newTestJson, undefined, 2 ) );
+  });
+}
+
+if( process.argv.length !== 3 ){
+  console.error( 'Incorrect number of arguments.' );
+  process.exit( 1 );
+}
+else {
+  updateTestFile( process.argv[ 2 ] );
+}

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -17,7 +17,7 @@ else
 		cd $repo_dest
 
 		# Checkout a branch, push the new test-cases.
-		date="$(date -I)"
+		date="$(date +%Y-%M-%d-%H-%M-%S)"
 		branchName="feedback_$date"
 		git checkout -q -b $branchName
 		git add test_cases/search.json

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -7,10 +7,10 @@ user=$2
 delay_before_pull=${3:-3}
 
 if [ -z $2 ]; then
-  echo "Usage: $0 [api_key] [user] {delay_before_pull}"
-  exit 1
+	echo "Usage: $0 [api_key] [user] {delay_before_pull}"
+	exit 1
 else
-  # Generate and add new test-cases.
+	# Generate and add new test-cases.
 	repo_dest=/tmp/acceptance-tests
 	git clone -q git@github.com:pelias/acceptance-tests $repo_dest
 	node generate_tests.js $repo_dest/test_cases/search.json
@@ -25,8 +25,8 @@ else
 		git commit -q -m "Feedback app test-cases for $date."
 		git push -q --set-upstream origin $branchName
 
-    # sleep before submitting our pull
-    sleep $delay_before_pull
+	# sleep before submitting our pull
+	sleep $delay_before_pull
 
 		# Open a pull request for the new branch.
 		curl --silent --show-error -X POST -H "Content-Type: application/json" \

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -1,16 +1,33 @@
-git clone git@github.com:pelias/acceptance-tests
-node generate_tests.js acceptance-tests/test_cases/search.json
-cd acceptance-tests
-branchName="feedback_$(date -I)"
-git checkout -b $branchName
-git add test_cases/search.json
-git commit -m "Feedback app test-cases for $(date -I)."
-git push --set-upstream origin $branchName
-# curl -X POST -H "Content-Type: application/json" -d '{
-  # "title": "Feedback App test cases for $(date -I )",
-  # "body": "",
-  # "head": "$branchName",
-  # "base": "master"
-# }' ssh://git@api.github.com:repos/pelias/acceptance-tests/pulls
-cd ..
-rm -rf acceptance-tests
+# A shell script that extracts new test-cases from the feedback app's MongoDB
+# collection, adds them to pelias/acceptance-tests's test-cases in a new
+# branch, and opens a pull request in that repository.
+
+api_key="$1"
+if [ "api_key" = "" ]; then
+	>&2 echo "No GitHub API key argument provided. Exiting."
+else
+	# Generate and add new test-cases.
+	git clone git@github.com:pelias/acceptance-tests
+	node generate_tests.js acceptance-tests/test_cases/search.json
+	cd acceptance-tests
+
+	# Checkout a branch, push the new test-cases.
+	date="$(date -I)"
+	branchName="feedback_$date"
+	git checkout -b $branchName
+	git add test_cases/search.json
+	git commit -m "Feedback app test-cases for $date."
+	git push --set-upstream origin $branchName
+
+	# Open a pull request for the new branch.
+	curl -X POST -H "Content-Type: application/json" \
+		-u sevko:$api_key -d '{
+			"title": "feedback app test cases for '$date'",
+			"body": "",
+			"head": "feedback_'$date'",
+			"base": "master"
+		}' https://api.github.com/repos/pelias/acceptance-tests/pulls
+
+	cd ..
+	rm -rf acceptance-tests
+fi

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -4,9 +4,10 @@
 
 api_key=$1
 user=$2
+delay_before_pull=${3:-3}
 
 if [ -z $2 ]; then
-  echo "Usage: $0 api_key user"
+  echo "Usage: $0 [api_key] [user] {delay_before_pull}"
   exit 1
 else
   # Generate and add new test-cases.
@@ -23,6 +24,9 @@ else
 		git add test_cases/search.json
 		git commit -q -m "Feedback app test-cases for $date."
 		git push -q --set-upstream origin $branchName
+
+    # sleep before submitting our pull
+    sleep $delay_before_pull
 
 		# Open a pull request for the new branch.
 		curl --silent --show-error -X POST -H "Content-Type: application/json" \

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -10,25 +10,27 @@ else
 	repo_dest=/tmp/acceptance-tests
 	git clone -q git@github.com:pelias/acceptance-tests $repo_dest
 	node generate_tests.js $repo_dest/test_cases/search.json
-	cd $repo_dest
+	if [ $? -eq 0 ]; then
+		cd $repo_dest
 
-	# Checkout a branch, push the new test-cases.
-	date="$(date -I)"
-	branchName="feedback_$date"
-	git checkout -q -b $branchName
-	git add test_cases/search.json
-	git commit -q -m "Feedback app test-cases for $date."
-	git push -q --set-upstream origin $branchName
+		# Checkout a branch, push the new test-cases.
+		date="$(date -I)"
+		branchName="feedback_$date"
+		git checkout -q -b $branchName
+		git add test_cases/search.json
+		git commit -q -m "Feedback app test-cases for $date."
+		git push -q --set-upstream origin $branchName
 
-	# Open a pull request for the new branch.
-	curl --silent --show-error -X POST -H "Content-Type: application/json" \
-		--user sevko:$api_key -d '{
-			"title": "feedback app test cases for '$date'",
-			"body": "",
-			"head": "feedback_'$date'",
-			"base": "master"
-		}' https://api.github.com/repos/pelias/acceptance-tests/pulls
+		# Open a pull request for the new branch.
+		curl --silent --show-error -X POST -H "Content-Type: application/json" \
+			--user sevko:$api_key -d '{
+				"title": "feedback app test cases for '$date'",
+				"body": "",
+				"head": "feedback_'$date'",
+				"base": "master"
+			}' https://api.github.com/repos/pelias/acceptance-tests/pulls
 
-	cd ..
-	rm -rf $repo_dest
+		cd ..
+	fi
 fi
+rm -rf $repo_dest

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -1,0 +1,16 @@
+git clone git@github.com:pelias/acceptance-tests
+node generate_tests.js acceptance-tests/test_cases/search.json
+cd acceptance-tests
+branchName="feedback_$(date -I)"
+git checkout -b $branchName
+git add test_cases/search.json
+git commit -m "Feedback app test-cases for $(date -I)."
+git push --set-upstream origin $branchName
+# curl -X POST -H "Content-Type: application/json" -d '{
+  # "title": "Feedback App test cases for $(date -I )",
+  # "body": "",
+  # "head": "$branchName",
+  # "base": "master"
+# }' ssh://git@api.github.com:repos/pelias/acceptance-tests/pulls
+cd ..
+rm -rf acceptance-tests

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -12,6 +12,10 @@ if [ -z $2 ]; then
 else
 	# Generate and add new test-cases.
 	repo_dest=/tmp/acceptance-tests
+  if [ -d $repo_dest]; then
+    rm -rf $repo_dest
+  fi
+
 	git clone -q git@github.com:pelias/acceptance-tests $repo_dest
 	node generate_tests.js $repo_dest/test_cases/search.json
 	if [ $? -eq 0 ]; then

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -6,7 +6,7 @@ api_key=$1
 user=$2
 
 if [ -z $2 ]; then
-  echo "Usage: $0 $api_key $user"
+  echo "Usage: $0 api_key user"
   exit 1
 else
   # Generate and add new test-cases.

--- a/upload-test-cases/upload.sh
+++ b/upload-test-cases/upload.sh
@@ -2,11 +2,14 @@
 # collection, adds them to pelias/acceptance-tests's test-cases in a new
 # branch, and opens a pull request in that repository.
 
-api_key="$1"
-if [ "$api_key" = "" ]; then
-	>&2 echo "No GitHub API key argument provided. Exiting."
+api_key=$1
+user=$2
+
+if [ -z $2 ]; then
+  echo "Usage: $0 $api_key $user"
+  exit 1
 else
-	# Generate and add new test-cases.
+  # Generate and add new test-cases.
 	repo_dest=/tmp/acceptance-tests
 	git clone -q git@github.com:pelias/acceptance-tests $repo_dest
 	node generate_tests.js $repo_dest/test_cases/search.json
@@ -23,7 +26,7 @@ else
 
 		# Open a pull request for the new branch.
 		curl --silent --show-error -X POST -H "Content-Type: application/json" \
-			--user sevko:$api_key -d '{
+			--user $user:$api_key -d '{
 				"title": "feedback app test cases for '$date'",
 				"body": "",
 				"head": "feedback_'$date'",


### PR DESCRIPTION
Add scripts to `/upload-test-cases` to facilitate extracting test-cases from the feedback app's MongoDB collection, and opening a pull request with the new additions in `pelias/acceptance-tests`.

Fixes #1 
